### PR TITLE
made the hand argument optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ riichi-hand-cli --help
 # example
 
 ```shell
+# interactive mode
+riichi-hand-cli
+# simple one hand
 riichi-hand-cli --name hand.png --tile yellow 123456789s567p99m
 # short hand command
 riichi-hand-cli -n hand.png -t yellow 123456789s567p99m

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,7 +24,7 @@ More examples:
 pub struct Args {
     /// Mahjong hand in human-readable format
     /// --help for more information
-    pub hand: String,
+    pub hand: Option<String>,
 
     /// Name and path of the image to save.
     /// If not specified, the image will be copied to clipboard

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,10 @@ fn main() {
     } = args;
     let options = RenderOptions::default();
 
-    process_hand(&hand, &name, &tile, options).unwrap();
-    if interactive {
+    if let Some(h) = &hand {
+        process_hand(&h, &name, &tile, options).unwrap();
+    }
+    if hand.is_none() || interactive {
         interactive_mode(&name, &tile, options);
     }
 }


### PR DESCRIPTION
Made the hand argument optional
If it is not passed it will automatically go to interactive mode
Supports entering interactive mode with options

example
```shell
riichi-hand-cli --tile black --name black.png
```